### PR TITLE
Add libmodulemd dbox-project

### DIFF
--- a/dnf-4.dbox.yaml
+++ b/dnf-4.dbox.yaml
@@ -267,3 +267,26 @@ test-smoke: >-
     cd ../../dnf-behave-tests &&
     LC_ALL=C behave -Ddnf_executable=dnf-3 -v features --no-skipped --tags=tier1
 ...
+---
+document: dbox-project
+document-version: 1
+name: libmodulemd
+clone: >-
+    gitc https://github.com/fedora-modularity/libmodulemd.git
+builddeps:
+    default: >-
+        dnf -y install jq clang git-core python3-pycodestyle python3-black redhat-rpm-config &&
+        dnf -y builddep libmodulemd
+configure: >-
+    meson ../..
+    --buildtype=debug
+    --prefix=/usr/
+    -Dwith_docs=false
+build: >-
+    ninja
+install: >-
+    ninja install
+# the unittests keep timeouting even though if run outside of container they work fine
+#unittest: >-
+    #MMD_SKIP_VALGRIND=True ninja test
+...


### PR DESCRIPTION
I didn't manage to get the unittests to finish on my setup, I have tried setting the buildtype to release but it didn't help.

Some of the timeouts can be configured in the cloned `./libmodulemd/modulemd/meson.build` but even with those working there still are others that use the default of 30s and fail.

(this problem may be specific just to my environment)
 